### PR TITLE
Add extra 'Show' contraint for GHC 7.4.1

### DIFF
--- a/src/Text/XFormat/Show.hs
+++ b/src/Text/XFormat/Show.hs
@@ -274,7 +274,7 @@ instance (Show a) => Format (ShowF a) (Arr a) where
 
 data NumF a = Num
 
-instance (Num a) => Format (NumF a) (Arr a) where
+instance (Num a, Show a) => Format (NumF a) (Arr a) where
   showsf' Num = Arr shows
 
 --------------------------------------------------------------------------------

--- a/xformat.cabal
+++ b/xformat.cabal
@@ -1,5 +1,5 @@
 name:                   xformat
-version:                0.1
+version:                0.1.1
 synopsis:
 
   Extensible, type-safe formatting with scanf- and printf-like functions
@@ -38,7 +38,7 @@ maintainer:             leather@cs.uu.nl
 stability:              experimental
 build-type:             Custom
 cabal-version:          >= 1.2.1
-tested-with:            GHC == 6.8.3, GHC == 6.10.1
+tested-with:            GHC == 6.8.3, GHC == 6.10.1, GHC == 7.4.1
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
GHC 7.4 removes the Eq and Show superclasses for Num, so this library needs a tiny change to build again. I also changed the version number to 0.1.1 due to the change.
